### PR TITLE
Fix error with Fawn.init in mongoose ^6.0.5

### DIFF
--- a/lib/fawn.js
+++ b/lib/fawn.js
@@ -89,7 +89,7 @@ function isMongoose(obj) {
     && obj.connections[0].otherDbs instanceof Array
     && obj.plugins instanceof Array
     && obj.models
-    && obj.modelSchemas
+    && (obj.modelSchemas || obj.Schema)
     && obj.options;
 }
 


### PR DESCRIPTION
There's an issue with initializing Fawn in mongoose ^6.0.5.  This comes from the isMongoose function. the `modelSchemas` object of the mongoose instance has been replaced with `Schema ` from the recent version of mongoose. So this leads to the function returning false even when the mongoose instance is valid