### PR TITLE
updated mongoose update function to Collection.updateMany

### DIFF
--- a/lib/task_core/goose.js
+++ b/lib/task_core/goose.js
@@ -53,7 +53,7 @@ exports.performUpdate = function(db, step, task, results) {
         doc.isNew = false;
         update = doc.save();
       }
-      else update = Collection.update(condition, data, step.options).exec();
+      else update = Collection.updateMany(condition, data, step.options).exec();
 
       return update.then(function (result) {
         results.push(result);


### PR DESCRIPTION
Collection.update function is deprecated by mongoose which is causing trouble to update multiple records.
Now using Collection.updateMany for updating records in mongoDB.